### PR TITLE
Fix uninitialized values in parseJSON

### DIFF
--- a/10_RHASSPY.pm
+++ b/10_RHASSPY.pm
@@ -694,16 +694,12 @@ sub RHASSPY_parseJSON($$) {
     }
 
     # Standard-Keys auslesen
-#    ($data->{'intent'} = $decoded->{'intent'}{'intentName'}) =~ s/^.*.://;
-if (exists($decoded->{'intent'})) {
-	($data->{'intent'} = $decoded->{'intent'}{'intentName'}) =~ s/^.*.://;
-    $data->{'probability'} = $decoded->{'intent'}{'confidenceScore'};
-}
-#    $data->{'probability'} = $decoded->{'intent'}{'confidenceScore'};
-    $data->{'sessionId'} = $decoded->{'sessionId'};
-    $data->{'siteId'} = $decoded->{'siteId'};
-    $data->{'input'} = $decoded->{'input'};
-    $data->{'rawInput'} = $decoded->{'rawInput'};
+    (($data->{'intent'} = $decoded->{'intent'}{'intentName'}) =~ s/^.*.://) unless (!exists($decoded->{'intent'}{'intentName'}));
+    $data->{'probability'} = $decoded->{'intent'}{'confidenceScore'}        unless (!exists($decoded->{'intent'}{'confidenceScore'}));
+    $data->{'sessionId'} = $decoded->{'sessionId'}                          unless (!exists($decoded->{'sessionId'}));
+    $data->{'siteId'} = $decoded->{'siteId'}                                unless (!exists($decoded->{'siteId'}));
+    $data->{'input'} = $decoded->{'input'}                                  unless (!exists($decoded->{'input'}));
+    $data->{'rawInput'} = $decoded->{'rawInput'}                            unless (!exists($decoded->{'rawInput'}));
 
 
     # Überprüfen ob Slot Array existiert


### PR DESCRIPTION
Schritte zum Reproduzieren des Fehlers: 
Nimm mal Deine aktuelle Version von github.
Mach ein tail -f fhem-2020-12.log 
und anschließend in fhem ein shutdown restart

Wenn nach 1 Minute alles wieder da ist, sag mal nur Dein wakeword und sonst nichts.

Du solltest sowas kriegen:

2020.12.19 14:29:18 1: PERL WARNING: Use of uninitialized value $value in concatenation (.) or string at ./FHEM/10_RHASSPY.pm line 727.

Hintergrund: Wenn man nur das Wakeword sagt, dann enthält $decoded etwas in dieser Art:
$VAR1 = {
          'siteId' => 'default',
          'lang' => undef,
          'sessionId' => 'default-terminator-d81e8781-c7a3-44f7-877e-c91e2deb4b27',
          'customData' => 'terminator'
        };

oder am Ende eines erfolgreichen Cycles etwas in dieser Art:
$VAR1 = {
          'sessionId' => 'default-terminator-afe8fb10-5b6d-4870-b1bc-a10cdaaabbc5',
          'siteId' => 'default',
          'termination' => {
                             'reason' => 'nominal'
                           },
          'customData' => 'terminator'
        };

In beiden Fällen fehlen diverse keys im JSON. 
Zwei der potentiell fehlenden Felder hast Du ja schon mit dem letzten commit mit umgesetzt.
Ich schlage vor, dass man keinen der Keys voraussetzt und jeden Key separat prüft.